### PR TITLE
 Test to make sure value is a string before trying to JSON.parse()

### DIFF
--- a/src/Traits/Jsonable.js
+++ b/src/Traits/Jsonable.js
@@ -23,16 +23,16 @@ class Jsonable {
 
     _afterSave (instance) {
         for (let field of this.fields) {
-            if (instance[field]) {
-                instance[field] = typeof instance[field] === 'string' ? JSON.parse(instance[field]) : instance[field]
+            if (instance[field] && typeof instance[field] === 'string') {
+                instance[field] = JSON.parse(instance[field])
             }
         }
     }
 
     _afterFind (instance) {
         for (let field of this.fields) {
-            if (instance[field]) {
-              instance[field] = typeof instance[field] === 'string' ? JSON.parse(instance[field]) : instance[field]
+            if (instance[field] && typeof instance[field] === 'string') {
+                instance[field] = JSON.parse(instance[field])
             }
         }
     }
@@ -40,8 +40,8 @@ class Jsonable {
     _afterFetch (instances) {
         for (let instance of instances) {
             for (let field of this.fields) {
-                if (instance[field]) {
-                  instance[field] = typeof instance[field] === 'string' ? JSON.parse(instance[field]) : instance[field]
+                if (instance[field] && typeof instance[field] === 'string') {
+                    instance[field] = JSON.parse(instance[field])
                 }
             }
         }

--- a/src/Traits/Jsonable.js
+++ b/src/Traits/Jsonable.js
@@ -24,7 +24,7 @@ class Jsonable {
     _afterSave (instance) {
         for (let field of this.fields) {
             if (instance[field]) {
-                instance[field] = JSON.parse(instance[field])
+                instance[field] = typeof instance[field] === 'string' ? JSON.parse(instance[field]) : instance[field]
             }
         }
     }
@@ -32,7 +32,7 @@ class Jsonable {
     _afterFind (instance) {
         for (let field of this.fields) {
             if (instance[field]) {
-              instance[field] = JSON.parse(instance[field])
+              instance[field] = typeof instance[field] === 'string' ? JSON.parse(instance[field]) : instance[field]
             }
         }
     }
@@ -41,7 +41,7 @@ class Jsonable {
         for (let instance of instances) {
             for (let field of this.fields) {
                 if (instance[field]) {
-                  instance[field] = JSON.parse(instance[field])
+                  instance[field] = typeof instance[field] === 'string' ? JSON.parse(instance[field]) : instance[field]
                 }
             }
         }


### PR DESCRIPTION
I'm using PG 10.1, the latest AdonisJS version, and a `jsonb` column. When I use this trait and query for a record with a field in the `jsonField` list that is holding an object, the value coming out of Lucid is actually an object and doesn't need to be `JSON.parse()`d.  It's actually the same for saving an object as well.  But you do need this trait for arrays (i.e. `['a', 'b', 'c']`).  So this will do a tiny bit of checking to make sure what is being parse is a string and not already an object.